### PR TITLE
Add nl (Dutch) errors.po translations

### DIFF
--- a/gettext/nl/LC_MESSAGES/errors.po
+++ b/gettext/nl/LC_MESSAGES/errors.po
@@ -1,0 +1,112 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: nl\n"
+
+## From Ecto.Changeset.cast/4
+msgid "can't be blank"
+msgstr "mag niet leeg zijn"
+
+## From Ecto.Changeset.unique_constraint/3
+msgid "has already been taken"
+msgstr "is al in gebruik"
+
+## From Ecto.Changeset.put_change/3
+msgid "is invalid"
+msgstr "is ongeldig"
+
+## From Ecto.Changeset.validate_acceptance/3
+msgid "must be accepted"
+msgstr "moet worden geaccepteerd"
+
+## From Ecto.Changeset.validate_format/3
+msgid "has invalid format"
+msgstr "heeft een ongeldige vorm"
+
+## From Ecto.Changeset.validate_subset/3
+msgid "has an invalid entry"
+msgstr "bevat een ongeldig item"
+
+## From Ecto.Changeset.validate_exclusion/3
+msgid "is reserved"
+msgstr "is gereserveerd"
+
+## From Ecto.Changeset.validate_confirmation/3
+msgid "does not match confirmation"
+msgstr "bevestiging is niet gelijk aan originele invoer"
+
+## From Ecto.Changeset.no_assoc_constraint/3
+msgid "is still associated with this entry"
+msgstr "is nog steeds verbonden aan dit item"
+
+msgid "are still associated with this entry"
+msgstr "zijn nog steeds verbonden aan dit item"
+
+## From Ecto.Changeset.validate_length/3
+msgid "should have %{count} item(s)"
+msgid_plural "should have %{count} item(s)"
+msgstr[0] "moet %{count} item hebben"
+msgstr[1] "moet %{count} items hebben"
+
+msgid "should be %{count} character(s)"
+msgid_plural "should be %{count} character(s)"
+msgstr[0] "moet %{count} teken lang zijn"
+msgstr[1] "moet %{count} tekens lang zijn"
+
+msgid "should be %{count} byte(s)"
+msgid_plural "should be %{count} byte(s)"
+msgstr[0] "moet %{count} byte hebben"
+msgstr[1] "moet %{count} bytes hebben"
+
+msgid "should have at least %{count} item(s)"
+msgid_plural "should have at least %{count} item(s)"
+msgstr[0] "moet minstens %{count} item hebben"
+msgstr[1] "moet minstens %{count} items hebben"
+
+msgid "should be at least %{count} character(s)"
+msgid_plural "should be at least %{count} character(s)"
+msgstr[0] "moet minstens %{count} teken lang zijn"
+msgstr[1] "moet minstens %{count} tekens lang zijn"
+
+msgid "should be at least %{count} byte(s)"
+msgid_plural "should be at least %{count} byte(s)"
+msgstr[0] "moet minstens %{count} byte zijn"
+msgstr[1] "moet minstens %{count} bytes zijn"
+
+msgid "should have at most %{count} item(s)"
+msgid_plural "should have at most %{count} item(s)"
+msgstr[0] "mag maximaal %{count} item hebben"
+msgstr[1] "mag maximaal %{count} items hebben"
+
+msgid "should be at most %{count} character(s)"
+msgid_plural "should be at most %{count} character(s)"
+msgstr[0] "mag maximaal %{count} teken lang zijn"
+msgstr[1] "mag maximaal %{count} tekens lang zijn"
+
+msgid "should be at most %{count} byte(s)"
+msgid_plural "should be at most %{count} byte(s)"
+msgstr[0] "mag maximaal %{count} byte zijn"
+msgstr[1] "mag maximaal %{count} bytes zijn"
+
+## From Ecto.Changeset.validate_number/3
+msgid "must be less than %{number}"
+msgstr "moet kleiner zijn dan %{number}"
+
+msgid "must be greater than %{number}"
+msgstr "moet groter zijn dan %{number}"
+
+msgid "must be less than or equal to %{number}"
+msgstr "moet kleiner zijn dan of gelijk zijn aan %{number}"
+
+msgid "must be greater than or equal to %{number}"
+msgstr "moet groter zijn dan of gelijk zijn aan %{number}"
+
+msgid "must be equal to %{number}"
+msgstr "moet gelijk zijn aan %{number}"


### PR DESCRIPTION
Thanks for creating this repo!

We've done some translation work for a handful of Ecto-using projects and thought it would be good to make our `errors.po` file available for other people in need of Dutch (NL) error message translations.

Note that this `errors.po` file has been checked against the current `main` `phx.new` generator `errors.po`. Permalink:

https://github.com/phoenixframework/phoenix/blob/74591ac2c499f217d0ca9f98e8e11599b651d776/installer/templates/phx_gettext/en/LC_MESSAGES/errors.po

The line numbers and base template messages should match exactly.